### PR TITLE
Update policy.json

### DIFF
--- a/modules/lb-controller/policy.json
+++ b/modules/lb-controller/policy.json
@@ -26,7 +26,8 @@
                 "elasticloadbalancing:DescribeTargetGroups",
                 "elasticloadbalancing:DescribeTargetGroupAttributes",
                 "elasticloadbalancing:DescribeTargetHealth",
-                "elasticloadbalancing:DescribeTags"
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:AddTags"
             ],
             "Resource": "*"
         },


### PR DESCRIPTION
Facing issue with forbidden error while setting up Loadbalancer service

(combined from similar events): Failed deploy model due to AccessDenied: User: blablabla is not authorized to perform: elasticloadbalancing:AddTags on resource: blablabla* because no identity-based policy allows the elasticloadbalancing:AddTags action status code: 403,